### PR TITLE
feat: initial KEDA scaling implementation

### DIFF
--- a/charts/core/Chart.yaml
+++ b/charts/core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.29.0
+version: 0.30.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/core/README.md
+++ b/charts/core/README.md
@@ -1,6 +1,6 @@
 # core
 
-![Version: 0.29.0](https://img.shields.io/badge/Version-0.29.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.30.0](https://img.shields.io/badge/Version-0.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 DHIS 2 Helm Chart
 
@@ -47,6 +47,15 @@ DHIS 2 Helm Chart
 | jobs.generateAnalytics.enabled | bool | `false` | Whether the "Generate Analytics" job is enabled. |
 | jobs.installApps.apps | list | `[{"name":"Capture","version":"latest"},{"name":"Dashboard","version":"latest"}]` | List of applications to install/update |
 | jobs.installApps.enabled | bool | `false` | Whether the "Install Apps" job is enabled. |
+| keda.enabled | bool | `false` | Whether to enable KEDA scaling or not. |
+| keda.initialCooldownPeriod | int | `600` | The delay before the cooldownPeriod starts after the initial creation |
+| keda.proxy | object | `{"hostname":"keda-add-ons-http-interceptor-proxy.keda.svc"}` | KEDA HTTP interceptor proxy hostname |
+| keda.replicas.max | int | `1` | Maximum number of replicas |
+| keda.replicas.min | int | `0` | Minimum number of replicas |
+| keda.scaledownPeriod | int | `300` | The delay before scaling down, starts after the last scaling event |
+| keda.scalingMetric.requestRate.granularity | string | `"1s"` |  |
+| keda.scalingMetric.requestRate.targetValue | int | `5` |  |
+| keda.scalingMetric.requestRate.window | string | `"30s"` |  |
 | livenessProbe.path | string | `"/"` | Path |
 | livenessProbe.timeoutSeconds | int | `1` | Timeout in seconds |
 | log4j2 | string | `"config/log4j2.xml"` | Path to the log4j2 configuration file. |

--- a/charts/core/templates/ingress.yaml
+++ b/charts/core/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ $fullName }}
+                name: {{ $fullName }}{{ if .Values.keda.enabled }}-keda-proxy{{ end }}
                 port:
                   number: {{ $svcPort }}
 {{- end }}

--- a/charts/core/templates/keda-scaling.yaml
+++ b/charts/core/templates/keda-scaling.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.keda.enabled }}
+kind: HTTPScaledObject
+apiVersion: http.keda.sh/v1alpha1
+metadata:
+  name: {{ include "dhis2-core-helm.fullname" . }}
+  labels:
+    {{- include "dhis2-core-helm.labels" . | nindent 4 }}
+spec:
+  hosts:
+    - {{ .Values.ingress.hostname | quote }}
+  pathPrefixes:
+    - {{ .Values.ingress.path }}
+  scaleTargetRef:
+    name: {{ include "dhis2-core-helm.fullname" . }}
+    kind: Deployment
+    apiVersion: apps/v1
+    service: {{ include "dhis2-core-helm.fullname" . }}
+    port: {{ .Values.service.port }}
+  replicas:
+    min: {{ .Values.keda.replicas.min }}
+    max: {{ .Values.keda.replicas.max }}
+  initialCooldownPeriod: {{ .Values.keda.initialCooldownPeriod }}
+  scaledownPeriod: {{ .Values.keda.scaledownPeriod }}
+  scalingMetric:
+    requestRate:
+      granularity: {{ .Values.keda.scalingMetric.requestRate.granularity }}
+      targetValue: {{ .Values.keda.scalingMetric.requestRate.targetValue }}
+      window: {{ .Values.keda.scalingMetric.requestRate.window }}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dhis2-core-helm.fullname" . }}-keda-proxy
+spec:
+  type: ExternalName
+  externalName: {{ .Values.keda.proxy.hostname }}
+{{- end }}

--- a/charts/core/values.yaml
+++ b/charts/core/values.yaml
@@ -234,6 +234,29 @@ ingress:
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
 
+# KEDA is a Kubernetes-based Event Driven Autoscaling component
+# Only support Nginx ingress controller... Service type: ExternalName
+keda:
+  # -- Whether to enable KEDA scaling or not.
+  enabled: false
+  replicas:
+    # -- Minimum number of replicas
+    min: 0
+    # -- Maximum number of replicas
+    max: 1
+  # -- The delay before the cooldownPeriod starts after the initial creation
+  initialCooldownPeriod: 600
+  # -- The delay before scaling down, starts after the last scaling event
+  scaledownPeriod: 300
+  # -- KEDA HTTP interceptor proxy hostname
+  proxy:
+    hostname: keda-add-ons-http-interceptor-proxy.keda.svc
+  scalingMetric:
+    requestRate:
+      granularity: 1s
+      targetValue: 5
+      window: 30s
+
 # -- Resource requests and limits for containers.
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/tests/minio/skaffold.yaml
+++ b/tests/minio/skaffold.yaml
@@ -81,3 +81,6 @@ deploy:
             # TODO: Should we actually target dev? At least configure this using an environment variable
             tag: 2.42
             pullPolicy: Always
+# TODO: Remove before merging to master
+          keda:
+            enabled: true


### PR DESCRIPTION
I manually installed KEDA in the EKS cluster using the below commands

    helm upgrade --install keda kedacore/keda --namespace keda --create-namespace

    helm upgrade --install http-add-on kedacore/keda-add-ons-http --namespace keda --set interceptor.replicas.waitTimeout=60s

The same needs to be done for any other cluster where we would like to use it.

KEDA itself works by deploying a HTTPScaledObject resource for each service we'd like to scale. We point our ingress towards the KEDA proxy server which will monitor activity and buffer any requests sent while our app is scaled to 0.
Since we can't reference services which aren't in the same namespace as our ingress. We also install an "alias" service within the current namespace which points to the KEDA proxy server running in the KEDA namespace.